### PR TITLE
Adds OA Opt-In form

### DIFF
--- a/forms-mit/opt-in.html
+++ b/forms-mit/opt-in.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <title>MIT Authors' Opt-in Open Access license : MIT Libraries</title>
+  <link href="/css/header-semantic.css" rel="stylesheet" type="text/css">
+  <link href="/css/wp-libraries.css" rel="stylesheet" type="text/css">
+  <!--#include virtual="/includes/base_scripts.html" -->
+  <style type="text/css">
+  .hidden {
+    display: none;
+  }
+  </style>
+  <script language="JavaScript" type="text/javascript">
+  <!--
+  $(document).ready(function() {
+    /** Add any load time jquery actions here */
+    var strPath = $(location).attr('pathname');
+    $('#submit').html('<input type="button" value="Send" onClick="check(form,form.elements.length);_gaq.push([\'_trackEvent\', \'Form\', \''+strPath+'\', \'Submit\']);">');
+  });
+//-->
+</script>
+<script type="text/javascript" src="/scripts/form-validator-2.0b.js"></script>
+<script type="text/javascript" src="/scripts/googleanalytics-async.js"></script>
+</head>
+
+<body>
+  <div id="container">
+    <!--#include virtual="/includes/header-semantic.html"-->
+    <!-- breadcrumb - TODO: make this semantic -->
+    <div class="breadcrumb">
+      <span class="semantic">You are located in:</span>
+      <ul>
+        <li><a href="/"><span class="semantic"></span>MIT Libraries</a></li>
+        <li><a href="/scholarly"><span class="semantic">in subsection </span>Scholarly Publishing</a></li>
+        <li><a href="/scholarly/mit-open-access/opt-in-oa-license"><span class="semantic">in subsection </span>Opt-in Open Access License</a></li>
+        <li><span class="semantic">on page </span>Opt In Form</li>
+      </ul>
+    </div>
+
+    <h1>MIT Authors' Opt-in Open Access License</h1>
+    <p>In 2009 the MIT faculty adopted a powerful and effective open access policy, which, through a license to MIT, allows authors to legally make their final, peer-reviewed manuscripts freely accessible through the open access repository <a href="http://dspace.mit.edu/handle/1721.1/49433">DSpace@MIT</a> and other venues.</p>
+    <p>As of April 2017, all MIT authors, including students, postdocs, and staff, have access to the same powerful means of retaining rights, via an <a href="/opt-in-license">"opt-in" open access license</a>.</p>
+    <p>Below is a voluntary, opt-in license that mirrors the language of the faculty open access policy. It applies to all scholarly articles written by an author after signing the license and while affiliated with MIT.</p>
+    <p>Authors covered by the <a href="/scholarly/mit-open-access/open-access-policy/">MIT Faculty Open Access Policy</a> do not need to sign this license.</p>
+    <form action="scripts/php/process.php" method="post" name="optin" id="optin">
+      <input type="hidden" name="subject" value="Open access policy opt-in license: <!--#echo var="displayname" -->">
+      <input type="hidden" name="recipient" value="oapolicyoptin@mit.edu">
+      <input type="hidden" name="fullname" value="<!--#echo var="displayname" -->">
+      <input type="hidden" name="email" value="<!--#echo var="eppn" -->">
+      <input type="hidden" name="copy" value="true">
+      <p><label>Your name</label><br><!--#echo var="displayname" --></p>
+      <p><label>Your email address</label><br><!--#echo var="eppn" --></p>
+      <div class="box">
+        <p>Authors at the Massachusetts Institute of Technology are committed to disseminating the fruits of their research and scholarship as widely as possible. In keeping with that commitment, by signing this license, I hereby grant to the Massachusetts Institute of Technology nonexclusive permission to make available my scholarly articles and to exercise the copyright in those articles for the purpose of open dissemination. In legal terms, I grant to MIT a nonexclusive, irrevocable, paid-up, worldwide license to exercise any and all rights under copyright relating to each of my scholarly articles, in any medium, provided that the articles are not sold for a profit, and to authorize others to do the same. This license will apply to all scholarly articles written while I am employed by, have an Academic Instructional Staff or Academic Research Staff (e.g., Postdoctoral Fellow) appointment from, or am registered as a student at MIT, except for any articles completed before the execution of this license and any articles for which I entered into an incompatible licensing or assignment agreement before the execution of this license. This license will not cover any article for which I notify MIT in writing that I am opting out of the license for that particular article. To assist the Institute in distributing the scholarly articles, as of the date of publication, I will make available an electronic copy of my final version of the article at no charge to a designated representative of the Provost's Office in appropriate formats (such as PDF) specified by the Provost's Office. I understand that the Provost's Office will make the scholarly article available to the public in an open-access repository.</p>
+        <p>
+          <label for="permission"><input name="permission" type="checkbox" id="permission" value="yes" aria-required="true">Yes, I grant this nonexclusive permission to MIT.</label>
+          <input type="hidden" name="r_permission" value="-Please check the box to indicate that you grant this nonexclusive permission to MIT.">
+        </p>
+      </div>
+      <p id="submit">
+        <input type="submit" value="Send">
+      </p>
+    </form>
+    <p>If you have any questions about working with the <a href="/opt-in-license">MIT Authors' Opt-in Open Access License</a>, please contact <a href="mailto:scholarlypub@mit.edu">scholarlypub@mit.edu</a>.</p>
+    <!--#include virtual="/includes/footer-semantic.html" -->
+  </div>
+</body>
+</html>

--- a/forms-text/opt-in.txt
+++ b/forms-text/opt-in.txt
@@ -1,0 +1,11 @@
+Thank you for signing the MIT Authors' Opt-in Open Access License. Below is the full text of the license for your records.
+
+If you have any questions, please email scholarlypub@mit.edu, or visit http://libraries.mit.edu/opt-in-license
+--- 
+
+Name: [>fullname<]
+Email: [>email<]
+
+Authors at the Massachusetts Institute of Technology are committed to disseminating the fruits of their research and scholarship as widely as possible. In keeping with that commitment, by signing this license, I hereby grant to the Massachusetts Institute of Technology nonexclusive permission to make available my scholarly articles and to exercise the copyright in those articles for the purpose of open dissemination. In legal terms, I grant to MIT a nonexclusive, irrevocable, paid-up, worldwide license to exercise any and all rights under copyright relating to each of my scholarly articles, in any medium, provided that the articles are not sold for a profit, and to authorize others to do the same. This license will apply to all scholarly articles written while I am employed by, have an Academic Instructional Staff or Academic Research Staff (e.g., Postdoctoral Fellow) appointment from, or am registered as a student at MIT, except for any articles completed before the execution of this license and any articles for which I entered into an incompatible licensing or assignment agreement before the execution of this license. This license will not cover any article for which I notify MIT in writing that I am opting out of the license for that particular article. To assist the Institute in distributing the scholarly articles, as of the date of publication, I will make available an electronic copy of my final version of the article at no charge to a designated representative of the Provost's Office in appropriate formats (such as PDF) specified by the Provost's Office. I understand that the Provost's Office will make the scholarly article available to the public in an open-access repository.
+
+Nonexclusive Permission: [>permission<]

--- a/forms-thanks/opt-in-thanks.html
+++ b/forms-thanks/opt-in-thanks.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <title>Thank you: MIT Authors' Opt-in Open Access license : MIT Libraries</title>
+  <link href="/css/header-semantic.css" rel="stylesheet" type="text/css">
+  <link href="/css/wp-libraries.css" rel="stylesheet" type="text/css">
+  <script type="text/javascript" src="/scripts/googleanalytics-async.js"></script>
+</head>
+
+<body>
+  <div id="container">
+    <!--#include virtual="/includes/header-semantic.html"-->
+    <!-- breadcrumb - TODO: make this semantic -->
+    <div class="breadcrumb">
+      <span class="semantic">You are located in:</span>
+      <ul>
+        <li><a href="/"><span class="semantic"></span>MIT Libraries</a></li>
+        <li><a href="/scholarly"><span class="semantic">in subsection </span>Scholarly Publishing</a></li>
+        <li><a href="/scholarly/mit-open-access/opt-in-oa-license"><span class="semantic">in subsection </span>Opt-in Open Access License</a></li>
+        <li><a href="/forms-mit/opt-in.html"><span class="semantic">on page </span>Opt In Form</a></li>
+        <li><span class="semantic">on page </span>Thank you</li>
+      </ul>
+    </div>
+    <h1>Thank you for signing the MIT Authors' Opt-in Open Access License</h1>
+    <p>If you have any questions, please email <a href="mailto:scholarlypub@mit.edu">scholarlypub@mit.edu</a>, or visit <a href="http://libraries.mit.edu/opt-in-license">http://libraries.mit.edu/opt-in-license</a></p>
+    <!--#include virtual="/includes/footer-semantic.html" -->
+  </div>
+</body>
+</html>


### PR DESCRIPTION
This adds a new form to the system, inside the secured `/forms-mit` directory, for the OA Opt In form. This has been requested by the Scholarly Communications group, and has been accepted by them.

On a technical basis, the form introduces no new functionality - and is one of the simpler forms we've built.

Also tagging @hllavina here to continue her onboarding