### PR TITLE
opt out email spacing fix

### DIFF
--- a/scripts/php/process.php
+++ b/scripts/php/process.php
@@ -196,7 +196,7 @@ class FormProcessor {
     if ($this->optOutRole == "Proxy") {
       $hello .= $this->optOutSubmitter . ", acting as a proxy for " . $this->optOutCoauthors;
     } else {
-      $hello .= $this->optOutRole . $this->optOutSubmitter . ", " . $this->optOutCoauthors;
+      $hello .= $this->optOutRole . " " . $this->optOutSubmitter . ", " . $this->optOutCoauthors;
     }
 
     return $hello;


### PR DESCRIPTION
Bug report submitted that there was no space between professor and name. This PR fixes that.