### PR TITLE
Set charset to email

### DIFF
--- a/scripts/php/process.php
+++ b/scripts/php/process.php
@@ -176,8 +176,8 @@ class FormProcessor {
       }
 
       $value = str_replace('$',' $ ',$value);
-
-      // drop value into message text
+	  
+	   // drop value into message text
       $this->messageText = preg_replace("/\[>" . $key . "<\]/U", $value, $this->messageText);
 
     }
@@ -343,6 +343,7 @@ class FormProcessor {
 
   private function sendCohortMessage () {
     $mail = new PHPMailer;
+    $mail->CharSet = "UTF-8";
     $mail->IsSendmail();
 
     $mail->SetFrom($this->from,$this->fromname);
@@ -371,6 +372,7 @@ class FormProcessor {
 
   private function sendMessage () {
     $mail = new PHPMailer;
+    $mail->CharSet = "UTF-8";
     $mail->IsSendmail();
 
     $mail->SetFrom($this->from,$this->fromname);


### PR DESCRIPTION

#### What does this PR do?
Updates charset for email sent by html forms to "UTF-8" to avoid special characters created when pasting from Word

#### How can a reviewer manually see the effects of these changes?

https://libraries-dev.mit.edu/forms/dspace-oa-articles.html

#### Requires new or updated plugins, themes, or libraries?
No
#### Requires change to deploy process?
No