### PR TITLE
Lengthens the URL field on Suggested Purchase form

### DIFF
--- a/forms-mit/purchase.html
+++ b/forms-mit/purchase.html
@@ -312,7 +312,7 @@
 
                       <label for="url">URL<br>
 
-                        <input type="text" name="url" id="url" size="35" maxlength="100">
+                        <input type="text" name="url" id="url" size="45" maxlength="255">
 
                       </label>
 


### PR DESCRIPTION
This lengthens the URL field on the Suggested Purchase form, from 100 characters to 255 characters. It also enlarges the display, from 35 characters to 45 characters.

If we need more than 255 characters, we should probably switch to a textarea field.