### PR TITLE
Adds study opt-in checkbox

### DIFF
--- a/forms-mit/ask.html
+++ b/forms-mit/ask.html
@@ -90,6 +90,9 @@
       <fieldset> 
        <legend>Personal Information</legend>
        <p>
+          <label for="study"><input name="study" type="checkbox" id="study" value="Yes" checked="checked"> I am willing to be contacted for participation in a research study related to my interaction with this service.</label>
+      </p>
+       <p>
         <label for="email">Your email address <abbr class="required" title="required">*</abbr><br>
           <input name="email" type="text" id="email" size="35" onChange="saveValue(this)" aria-required="true">
         </label>

--- a/forms-text/ask.txt
+++ b/forms-text/ask.txt
@@ -1,46 +1,48 @@
-Topic: [>topic<]
-
-Subject: [>subject<]
-
-Question:  
-
-[>question<] 
-
-Email:  [>email<]
-
-Last name:  [>lastname<]
-
-First name:  [>firstname<]
-
-Phone:  [>phone<]
-
-Status:  [>status<]
-
-Department:  [>department<]
-
-Lab or center: [>lab<]
-
---- Client Information ---
-Web Browser: [>client-browser<]
-
-IP Address: [>client-ip<]
-
---- Technical Information ---
-[>technical-details<]
-
-[>offcampus<]
-
-[>vpn<]
-
---- ILB Information ---
-[>ilb-topic<]
-
-[>ilb-number<]
-
-[>ilb-title<]
-
-[>ilb-author<]
-
-[>ilb-article<]
-
+Topic: [>topic<]
+
+Subject: [>subject<]
+
+Question:
+
+[>question<]
+
+Study opt-in:  [>study<]
+
+Email:  [>email<]
+
+Last name:  [>lastname<]
+
+First name:  [>firstname<]
+
+Phone:  [>phone<]
+
+Status:  [>status<]
+
+Department:  [>department<]
+
+Lab or center: [>lab<]
+
+--- Client Information ---
+Web Browser: [>client-browser<]
+
+IP Address: [>client-ip<]
+
+--- Technical Information ---
+[>technical-details<]
+
+[>offcampus<]
+
+[>vpn<]
+
+--- ILB Information ---
+[>ilb-topic<]
+
+[>ilb-number<]
+
+[>ilb-title<]
+
+[>ilb-author<]
+
+[>ilb-article<]
+
 [>ilb-year<]


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This adds a checkbox to the Ask Us form, allowing users to opt-in or opt-out of a short term research study being conducted by the Libraries.

#### How can a reviewer manually see the effects of these changes?
Load the Ask Us form on the development server, and send some tickets in to watch how the email template looks.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-278

#### Todo:
- [X] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
