### PR TITLE
Removes opt-in checkbox from Ask Us form (enrollment period has concl…

### DIFF
--- a/forms-mit/ask.html
+++ b/forms-mit/ask.html
@@ -90,9 +90,6 @@
       <fieldset> 
        <legend>Personal Information</legend>
        <p>
-          <label for="study"><input name="study" type="checkbox" id="study" value="Yes" checked="checked"> I am willing to be contacted for participation in a research study related to my interaction with this service.</label>
-      </p>
-       <p>
         <label for="email">Your email address <abbr class="required" title="required">*</abbr><br>
           <input name="email" type="text" id="email" size="35" onChange="saveValue(this)" aria-required="true">
         </label>

--- a/forms-text/ask.txt
+++ b/forms-text/ask.txt
@@ -6,8 +6,6 @@ Question:
 
 [>question<]
 
-Study opt-in:  [>study<]
-
 Email:  [>email<]
 
 Last name:  [>lastname<]


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This removes the changes made in #40, now that the study enrollment period has concluded.

#### Helpful background context (if appropriate)
The previous change added an opt-in checkbox to the Ask Us form, asking submitters if they wanted to be contacted regarding a study that is beginning in the Libraries. Now that the enrollment period is over, this checkbox is no longer needed.

#### How can a reviewer manually see the effects of these changes?
This branch has been deployed on the dev and test servers, so checking the Ask Us form there should show a form without this checkbox (which was at the top of the Personal Information fieldset)

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-278

#### Screenshots (if appropriate)
Before - with checkbox
![image](https://user-images.githubusercontent.com/1403248/37909618-61efcc7a-30d9-11e8-92a5-eb720c12f4dc.png)

After - without checkbox
![image](https://user-images.githubusercontent.com/1403248/37909663-866264b4-30d9-11e8-8867-f5a733da5961.png)

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
